### PR TITLE
send keep alive on serve to instantly trigger SSE onopen

### DIFF
--- a/request.go
+++ b/request.go
@@ -67,6 +67,8 @@ func serveRequest(
 	keepAliveMsgBytes []byte,
 ) {
 	_, _ = writer.Write(replay)
+	// send keep alive on serve to instantly trigger SSE onopen in firefox and chrome
+	_, _ = writer.Write(keepAliveMsgBytes)
 
 	timer := time.NewTimer(keepAliveInterval)
 	defer timer.Stop()


### PR DESCRIPTION
Firefox only triggers SSE onopen (at least when using fetch https://github.com/Azure/fetch-event-source) if anything is send over SSE. Always sending keep alive on serve will reliably trigger onopen.